### PR TITLE
Correct ids_with_problems, bowtie run, remove reference index, version check, remove fastq

### DIFF
--- a/SeqFromWebTaxon.py
+++ b/SeqFromWebTaxon.py
@@ -102,7 +102,6 @@ def GetSequencesFromTaxon(taxonname,outputfile,getmachine):
 						length_line = len(line)
 					sys.stderr.write("\r" + line + ' '*(length_line - len(line)))
 					sys.stderr.flush()
-					length_line = len(line)
 		print "\n"
 		print "\nfound %s run id's" % n
 		

--- a/SeqFromWebTaxon.py
+++ b/SeqFromWebTaxon.py
@@ -64,6 +64,7 @@ def GetSequencesFromTaxon(taxonname,outputfile,getmachine):
 				
 
 				if getmachine is True:
+					length_line = 0
 					for child2 in child:
 						if child2.tag == 'EXPERIMENT_REF':
 							expid=child2.get('accession')
@@ -89,12 +90,16 @@ def GetSequencesFromTaxon(taxonname,outputfile,getmachine):
 					
 									
 					f.write(str(runid)+"\t"+model+"\t"+prjid+"\n")
-					sys.stderr.write("\r" + "run acession %s sequenced on %s from project %s" % (runid, model,prjid))
+					line = "run acession %s sequenced on %s from project %s" % (runid, model,prjid)
+					sys.stderr.write("\r" + line + ' '*max((length_line - len(line)), 0))
 					sys.stderr.flush()
+					length_line = len(line)
 				else:
-					f.write(str(runid)+"\n")								
-					sys.stderr.write("\r" + "run acession %s" % (runid,prjid))
+					f.write(str(runid)+"\n")
+					line = "run acession %s" % (runid,prjid)
+					sys.stderr.write("\r" + line + ' '*max((length_line - len(line)), 0))
 					sys.stderr.flush()
+					length_line = len(line)
 		print "\n"
 		print "\nfound %s run id's" % n
 		

--- a/SeqFromWebTaxon.py
+++ b/SeqFromWebTaxon.py
@@ -91,13 +91,14 @@ def GetSequencesFromTaxon(taxonname,outputfile,getmachine):
 									
 					f.write(str(runid)+"\t"+model+"\t"+prjid+"\n")
 					line = "run acession %s sequenced on %s from project %s" % (runid, model,prjid)
-					sys.stderr.write("\r" + line + ' '*max((length_line - len(line)), 0))
+					sys.stderr.write("\r" + line + ' '*(length_line - len(line)))
 					sys.stderr.flush()
-					length_line = len(line)
 				else:
 					f.write(str(runid)+"\n")
 					line = "run acession %s" % (runid,prjid)
-					sys.stderr.write("\r" + line + ' '*max((length_line - len(line)), 0))
+					if length_line < len(line):
+						length_line = len(line)
+					sys.stderr.write("\r" + line + ' '*(length_line - len(line)))
 					sys.stderr.flush()
 					length_line = len(line)
 		print "\n"

--- a/SeqFromWebTaxon.py
+++ b/SeqFromWebTaxon.py
@@ -63,8 +63,8 @@ def GetSequencesFromTaxon(taxonname,outputfile,getmachine):
 				n+=1
 				
 
+				length_line = 0
 				if getmachine is True:
-					length_line = 0
 					for child2 in child:
 						if child2.tag == 'EXPERIMENT_REF':
 							expid=child2.get('accession')
@@ -91,6 +91,8 @@ def GetSequencesFromTaxon(taxonname,outputfile,getmachine):
 									
 					f.write(str(runid)+"\t"+model+"\t"+prjid+"\n")
 					line = "run acession %s sequenced on %s from project %s" % (runid, model,prjid)
+					if length_line < len(line):
+						length_line = len(line)
 					sys.stderr.write("\r" + line + ' '*(length_line - len(line)))
 					sys.stderr.flush()
 				else:

--- a/SeqFromWebTaxon.py
+++ b/SeqFromWebTaxon.py
@@ -57,13 +57,13 @@ def GetSequencesFromTaxon(taxonname,outputfile,getmachine):
 			model=''
 			prjid=''
 			models={}
+			length_line = 0
 			for child in tree:
 				runid=child.get('accession')
 				
 				n+=1
 				
 
-				length_line = 0
 				if getmachine is True:
 					for child2 in child:
 						if child2.tag == 'EXPERIMENT_REF':

--- a/SeqFromWebTaxon.py
+++ b/SeqFromWebTaxon.py
@@ -44,7 +44,7 @@ def GetSequencesFromTaxon(taxonname,outputfile,getmachine):
 	for child in tree:
 		taxonid=child.get('taxId')
 	if (taxonid):
-		print "Taxon found: "+taxonid
+		print "Taxon ID found: "+taxonid
 		url="http://www.ebi.ac.uk/ena/data/warehouse/search?query=%22tax_tree%28"+taxonid+"%29%22&result=read_run&display=xml"
 
 		content = urllib2.urlopen(url)
@@ -88,12 +88,12 @@ def GetSequencesFromTaxon(taxonname,outputfile,getmachine):
 								model='not found'
 					
 									
-					f.write(str(runid)+"\t"+model+"\t"+prjid+"\n")								
-					print "run acession %s sequenced on %s from project %s" % (runid, model,prjid)
+					f.write(str(runid)+"\t"+model+"\t"+prjid+"\n")
+					sys.stderr.write("\r" + "run acession %s sequenced on %s from project %s" % (runid, model,prjid))
 				else:
 					f.write(str(runid)+"\n")								
-					print "run acession %s" % (runid,prjid)
-				
+					sys.stderr.write("\r" + "run acession %s" % (runid,prjid))
+		print "\n"
 		print "\nfound %s run id's" % n
 		
 	else:

--- a/SeqFromWebTaxon.py
+++ b/SeqFromWebTaxon.py
@@ -44,7 +44,7 @@ def GetSequencesFromTaxon(taxonname,outputfile,getmachine):
 	for child in tree:
 		taxonid=child.get('taxId')
 	if (taxonid):
-		print "Taxon ID found: "+taxonid
+		print "\n" + "Taxon ID found: "+taxonid
 		url="http://www.ebi.ac.uk/ena/data/warehouse/search?query=%22tax_tree%28"+taxonid+"%29%22&result=read_run&display=xml"
 
 		content = urllib2.urlopen(url)
@@ -90,9 +90,11 @@ def GetSequencesFromTaxon(taxonname,outputfile,getmachine):
 									
 					f.write(str(runid)+"\t"+model+"\t"+prjid+"\n")
 					sys.stderr.write("\r" + "run acession %s sequenced on %s from project %s" % (runid, model,prjid))
+					sys.stderr.flush()
 				else:
 					f.write(str(runid)+"\n")								
 					sys.stderr.write("\r" + "run acession %s" % (runid,prjid))
+					sys.stderr.flush()
 		print "\n"
 		print "\nfound %s run id's" % n
 		

--- a/downloadAndBowtie.py
+++ b/downloadAndBowtie.py
@@ -202,7 +202,6 @@ def downloadAndBowtie(referencePath, run_id, target_dir, buildBowtie, picardJarP
 		os.makedirs(resultsFolder)
 	
 	bowtie_output_file=os.path.join(resultsFolder, str(run_id + '.sam'))
-	# bowtieLog = os.path.join(resultsFolder, run_id + "_bowtie_error.txt")
 	
 	pairedOrSingle="Single_end"	
 
@@ -213,15 +212,6 @@ def downloadAndBowtie(referencePath, run_id, target_dir, buildBowtie, picardJarP
 	if len(downloadedFiles)==1:
 		bowtie_command[7] = str('-U ' + os.path.join(dir_with_gz, downloadedFiles[0]))
 		bowtie_command_splitted = shlex.split(' '.join(bowtie_command))
-		'''
-		print ' '.join(bowtie_command)
-		myoutput = open(bowtieLog, 'w')
-		proc = subprocess.call(bowtie_command, stdout=myoutput, stderr=myoutput)
-		myoutput.close()
-		if proc != 0:
-			print 'Bowtie2 fails! Find Bowtie2 log file at ' + bowtieLog
-			return False, False, downloadedFiles
-		'''
 		proc = subprocess.Popen(bowtie_command_splitted, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 		stdout, stderr = proc.communicate()
 		if proc.returncode != 0:
@@ -231,15 +221,6 @@ def downloadAndBowtie(referencePath, run_id, target_dir, buildBowtie, picardJarP
 	elif len(downloadedFiles)==2:
 		bowtie_command[7] = str('-1 ' + os.path.join(dir_with_gz, downloadedFiles[0]) + ' -2 ' + os.path.join(dir_with_gz, downloadedFiles[1]))
 		bowtie_command_splitted = shlex.split(' '.join(bowtie_command))
-		'''
-		print ' '.join(bowtie_command)
-		myoutput = open(bowtieLog, 'w')
-		proc = subprocess.call(bowtie_command, stdout=myoutput, stderr=myoutput)
-		myoutput.close()
-		if proc != 0:
-			print 'Bowtie2 fails! Find Bowtie2 log file at ' + bowtieLog
-			return False, False, downloadedFiles
-		'''
 		proc = subprocess.Popen(bowtie_command_splitted, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 		stdout, stderr = proc.communicate()
 		if proc.returncode != 0:
@@ -251,6 +232,5 @@ def downloadAndBowtie(referencePath, run_id, target_dir, buildBowtie, picardJarP
 		os.system('rm -r ' + dir_with_gz)
 		return False, False, downloadedFiles
 
-	# toClear.append(os.path.join(resultsFolder, run_id+"_bowtie_error.txt"))
 	toClear.append(os.path.join(resultsFolder, run_id+".bowtie_metrics.txt"))
 	return bowtie_output_file, pairedOrSingle, downloadedFiles

--- a/downloadAndBowtie.py
+++ b/downloadAndBowtie.py
@@ -28,9 +28,9 @@ import shutil
 
 from os import listdir
 from os.path import isfile, join
-from threading import Timer ## mpmachado ##
+from threading import Timer
 
-def runTimeoutLimit(command_fragmented_in_list, timeout_sec): ## mpmachado ##
+def runTimeoutLimit(command_fragmented_in_list, timeout_sec):
 	proc = subprocess.Popen(command_fragmented_in_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 	timer = Timer(timeout_sec, proc.kill)
 	timer.start()
@@ -39,18 +39,7 @@ def runTimeoutLimit(command_fragmented_in_list, timeout_sec): ## mpmachado ##
 	return proc.returncode, stdout.decode("utf-8"), stderr.decode("utf-8")
 
 def download(dirs2,target_dir2,ref2,success2,f2,link2):
-	#new folder for each reference with reference id name
-	# subprocess.call(['mkdir', target_dir2+"/"+ref2]) # mpmachado #
-	
-	#get fasta file for each read file name
-	#numFilesInDir = len(dirs2)
 	insucess=0
-
-	'''if numFilesInDir > 2:
-		print "more than 2 files"
-		#logFile.write("more than 2 files" + '\n')
-		return success2 
-	'''
 	for item in dirs2:
 					
 		try:
@@ -58,13 +47,11 @@ def download(dirs2,target_dir2,ref2,success2,f2,link2):
 			final_target_dir=target_dir2+"/"+ item
 			file = open(final_target_dir, 'wb')
 			print "Downloading: %s" % item
-			#logFile.write("Downloading: %s\n" % item)
 
 			f2.retrbinary('RETR %s' % item, file.write)
 			file.close()
 			print "Downloaded %s" % item
-			#logFile.write("Downloaded %s\n" % item)
-			success2+=1		
+			success2+=1
 		except Exception as e:
 			print e
 			insucess+=1
@@ -73,10 +60,7 @@ def download(dirs2,target_dir2,ref2,success2,f2,link2):
 
 def download_ERR(ERR_id,target_dir):
 	
-	# if not os.path.isdir(target_dir): # mpmachado #
-		# os.makedirs(target_dir) # mpmachado #
-	
-	f=ftplib.FTP('ftp.sra.ebi.ac.uk', timeout=3600) # mpmachado #
+	f=ftplib.FTP('ftp.sra.ebi.ac.uk', timeout=3600)
 	f.login()
 	#for each reference id get the read files
 	ref=ERR_id
@@ -105,7 +89,6 @@ def download_ERR(ERR_id,target_dir):
 		except Exception, e:
 			failed +=1
 			print "Bad ID: " + ref
-			#logFile.write("Bad ID: " + ref + '\n')
 		else:
 			success,insucess=download(dirs,target_dir,ref,success,f,link)	
 			
@@ -117,11 +100,11 @@ def download_ERR(ERR_id,target_dir):
 	except Exception, e:
 		print e
 		print 'Insucess: ' + str(insucess)
-	print "Successfully downloaded %s files and %s ID references were wrong" % (success,failed)	
-	#logFile.write("Successfully downloaded %s files and %s ID references were wrong\n" % (success,failed))
+	print "Downloaded %s files successfully, %s fail and %s ID references were wrong" % (success,insucess,failed)
 	return insucess
 
-def downloadAspera(run_id, outdir, asperaKey): ## mpmachado ##
+# Download using Aspera Connect
+def downloadAspera(run_id, outdir, asperaKey):
 	aspera_run = False
 	aspera_command = ['ascp', '-QT', '-l', '300m', '-i', asperaKey, str('era-fasp@fasp.sra.ebi.ac.uk:/vol1/fastq/' + run_id[0:6] + '/' + run_id), outdir]
 	aspera, std_out, std_err = runTimeoutLimit(aspera_command, 3600)
@@ -137,9 +120,8 @@ def downloadAspera(run_id, outdir, asperaKey): ## mpmachado ##
 		if aspera == 0:
 			aspera_run = True
 		else:
-			print "Download using Aspera didn't work" + "\n"
+			print "Download using Aspera didn't work"
 			return aspera_run
-	
 	files = glob.glob1(os.path.join(outdir, run_id), '*')
 	for file in files:
 		shutil.move(os.path.join(outdir, run_id, file), outdir)
@@ -147,7 +129,7 @@ def downloadAspera(run_id, outdir, asperaKey): ## mpmachado ##
 	return aspera_run
 
 # Search Fastq files (that were downloaded or already provided by the user)
-def searchDownloadedFiles(directory): ## mpmachado ##
+def searchDownloadedFiles(directory):
 	filesExtensions = ['fastq.gz', 'fq.gz']
 	for extension in filesExtensions:
 		downloadedFiles = glob.glob1(directory, str('*.' + extension))
@@ -155,64 +137,51 @@ def searchDownloadedFiles(directory): ## mpmachado ##
 			break
 	return downloadedFiles
 
+def downloadAndBowtie(referencePath, run_id, target_dir, buildBowtie, picardJarPath, threads, toClear, asperaKey):
 
-def downloadAndBowtie(referencePath, run_id, target_dir, buildBowtie, picardJarPath, threads, toClear, asperaKey): # mpmachado #
-
-	bowtieBuildFileName, extension = os.path.splitext(referencePath) # mpmachado #
+	bowtieBuildFileName, extension = os.path.splitext(referencePath)
 
 	if buildBowtie == True:
 		print "Indexing Reference file..."
-		#logFile.write("Running picard" + '\n')
 		picardFileName, extension = os.path.splitext(referencePath)
 		os.system('java -jar ' + picardJarPath +" CreateSequenceDictionary R= " + referencePath + " O= " + picardFileName + ".dict 2> "+picardFileName+"_picard_out.txt")
-		#toClear.append(picardFileName+"_picard_out.txt")
-		#toClear.append(picardFileName + ".dict")
-		#toClear.append(referencePath+'.fai')
-		
-	# if buildBowtie == True: # mpmachado #
-		#logFile.write("Running bowtie..." + '\n')
+
 		bowtiBuildeLog=bowtieBuildFileName +"_bowtiBuildLog.txt"
 		myoutput = open(bowtiBuildeLog, 'w')
 		subprocess.call(["bowtie2-build", referencePath, bowtieBuildFileName],stdout=myoutput,stderr=myoutput)
-		#toClear.append(bowtieBuildFileName + ".*.bt2")
-		#toClear.append(bowtiBuildeLog)
 	
-	if not os.path.isdir(target_dir): # mpmachado #
-		os.makedirs(target_dir) # mpmachado #
+	if not os.path.isdir(target_dir):
+		os.makedirs(target_dir)
 	dir_sample = os.path.join(target_dir,run_id)
-	if not os.path.isdir(dir_sample): # mpmachado #
-		os.makedirs(dir_sample) # mpmachado #
+	if not os.path.isdir(dir_sample):
+		os.makedirs(dir_sample)
 
 	dir_with_gz = os.path.join(target_dir,run_id, 'fastq')
-	if not os.path.isdir(dir_with_gz): # mpmachado #
-		os.makedirs(dir_with_gz) # mpmachado #
+	if not os.path.isdir(dir_with_gz):
+		os.makedirs(dir_with_gz)
 	
 	#download ERR
 	aspera_run = False
 	ftp_down_insuc = 0
 	
-	# numberFilesDowned= len(glob.glob1(dir_with_gz, "*.fastq.gz")) # mpmachado #
-	downloadedFiles = searchDownloadedFiles(dir_with_gz) # mpmachado #
-	if len(downloadedFiles) < 1: # mpmachado #
+	downloadedFiles = searchDownloadedFiles(dir_with_gz)
+	if len(downloadedFiles) < 1:
 		print 'Trying download...'
-		if asperaKey != None: ## mpmachado ##
-			aspera_run = downloadAspera(run_id, dir_with_gz, asperaKey[0]) ## mpmachado ##
+		if asperaKey != None:
+			aspera_run = downloadAspera(run_id, dir_with_gz, asperaKey[0])
 			if aspera_run == False:
-				print 'Trying download using FTP' + "\n" ## mpmachado ##
-				ftp_down_insuc=download_ERR(run_id, dir_with_gz) ## mpmachado ##
-				
-				
-		else: ## mpmachado ##
-			ftp_down_insuc=download_ERR(run_id, dir_with_gz) # mpmachado #
+				print 'Trying download using FTP'
+				ftp_down_insuc=download_ERR(run_id, dir_with_gz)
+		else:
+			ftp_down_insuc=download_ERR(run_id, dir_with_gz)
 	else:
-		print 'File '+ run_id+' already exists...' 
-		#logFile.write('File '+ run_id+' already exists...' + '\n')
+		print 'File '+ run_id + ' already exists...' 
 	
-	downloadedFiles = searchDownloadedFiles(dir_with_gz) # mpmachado #
+	downloadedFiles = searchDownloadedFiles(dir_with_gz)
 	
 	if ftp_down_insuc > 0 and aspera_run == False:
 		os.system('rm -r ' + dir_with_gz)
-		return False, False, downloadedFiles # mpmachado #
+		return False, False, downloadedFiles, False
 		
 	
 	if len(downloadedFiles) > 2:
@@ -233,44 +202,31 @@ def downloadAndBowtie(referencePath, run_id, target_dir, buildBowtie, picardJarP
 		os.makedirs(resultsFolder)
 	
 	bowtie_output_file=os.path.join(resultsFolder, run_id + ".sam")
-	bowtieLog = os.path.join(resultsFolder, run_id + "_bowtie_error.txt")
 	
 	pairedOrSingle="Single_end"	
 
 	print "Running bowtie..."
+	
+	bowtie_command = ['bowtie2', '-k', str(2), '--quiet', '--no-unal', '-x', bowtieBuildFileName, str('-U ' + os.path.join(dir_with_gz, downloadedFiles[0])), str('--rg-id ENA --rg SM:' + run_id), '--sensitive-local', '--threads', str(threads), '--met-file', os.path.join(resultsFolder, str(run_id + '.bowtie_metrics.txt')), '-S', bowtie_output_file]
+	
 	if len(downloadedFiles)==1:
-
-
-		command_line ="bowtie2 -k 2 --quiet --no-unal -x "+bowtieBuildFileName+" -U "+dir_with_gz+"/"+downloadedFiles[0] + " --rg-id ENA --rg SM:"+run_id+" --sensitive-local --threads "+ str(threads) +" --met-file "+ os.path.join(resultsFolder, run_id+".bowtie_metrics.txt") + " -S "+bowtie_output_file+" "
-
-
-		myoutput = open(bowtieLog, 'w')
-		args = shlex.split(command_line)
-		p = subprocess.call(args,stdout=myoutput,stderr=myoutput)
-		toClear.append(os.path.join(resultsFolder, run_id+".bowtie_metrics.txt"))
-		toClear.append(os.path.join(resultsFolder, run_id+"_bowtie_error.txt"))
-
-
+		proc = subprocess.Popen(bowtie_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+		stdout, stderr = proc.communicate()
+		if proc.returncode != 0:
+			print stdout.decode("utf-8"), stderr.decode("utf-8")
+			return False, False, downloadedFiles
 	elif len(downloadedFiles)==2:
-
-		command_line ="bowtie2 -k 2 --quiet --no-unal -x "+bowtieBuildFileName+" -1 "+dir_with_gz+"/"+downloadedFiles[0]+ " -2 "+dir_with_gz+"/"+downloadedFiles[1] + " --rg-id ENA --rg SM:"+run_id+" --sensitive-local --threads "+ str(threads) +" --met-file "+ os.path.join(resultsFolder, run_id+".bowtie_metrics.txt") + " -S "+bowtie_output_file+" "
-		
-		myoutput = open(bowtieLog, 'w')
-		args = shlex.split(command_line)
-		p = subprocess.call(args,stdout=myoutput,stderr=myoutput)
-		pairedOrSingle="Paired_end"	
-		toClear.append(os.path.join(resultsFolder, run_id+".bowtie_metrics.txt"))
-		toClear.append(os.path.join(resultsFolder, run_id+"_bowtie_error.txt"))
-
-	
+		bowtie_command[7] = str('-1 ' + os.path.join(dir_with_gz, downloadedFiles[0]) + ' -2 ' + os.path.join(dir_with_gz, downloadedFiles[1]))
+		proc = subprocess.Popen(bowtie_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+		stdout, stderr = proc.communicate()
+		if proc.returncode != 0:
+			print stdout.decode("utf-8"), stderr.decode("utf-8")
+			return False, False, downloadedFiles
 	else:
-		
-		print "0 fastq files found. Aborting...\n"
-		#logFile.write("0 fastq files found. Aborting..." + '\n')
+		print "0 fastq files found. Aborting..."
 		os.system('rm -r ' + dir_with_gz)
-		return False, False, downloadedFiles # mpmachado #
+		return False, False, downloadedFiles
 
-	
-	return bowtie_output_file, pairedOrSingle, downloadedFiles # mpmachado #
-
-
+	toClear.append(os.path.join(resultsFolder, run_id+".bowtie_metrics.txt"))
+	toClear.append(os.path.join(resultsFolder, run_id+"_bowtie_error.txt"))
+	return bowtie_output_file, pairedOrSingle, downloadedFiles

--- a/downloadAndBowtie.py
+++ b/downloadAndBowtie.py
@@ -110,7 +110,6 @@ def downloadAspera(run_id, outdir, asperaKey):
 	aspera, std_out, std_err = runTimeoutLimit(aspera_command, 3600)
 	if aspera == 0:
 		aspera_run = True
-		print ' '.join(aspera_command)
 	else:
 		print "Connecting using the following command didn't work:"
 		print ' '.join(aspera_command)

--- a/downloadAndBowtie.py
+++ b/downloadAndBowtie.py
@@ -214,19 +214,21 @@ def downloadAndBowtie(referencePath, run_id, target_dir, buildBowtie, picardJarP
 	
 	if len(downloadedFiles)==1:
 		bowtie_command[7] = str('-U ' + os.path.join(dir_with_gz, downloadedFiles[0]))
+		print ' '.join(bowtie_command)
 		myoutput = open(bowtieLog, 'w')
 		proc = subprocess.call(bowtie_command, stdout=myoutput, stderr=myoutput)
 		myoutput.close()
 		if proc != 0:
-			print 'Bowtie2 fails! Find Bowtie2 log file at' + bowtieLog
+			print 'Bowtie2 fails! Find Bowtie2 log file at ' + bowtieLog
 			return False, False, downloadedFiles
 	elif len(downloadedFiles)==2:
 		bowtie_command[7] = str('-1 ' + os.path.join(dir_with_gz, downloadedFiles[0]) + ' -2 ' + os.path.join(dir_with_gz, downloadedFiles[1]))
+		print ' '.join(bowtie_command)
 		myoutput = open(bowtieLog, 'w')
 		proc = subprocess.call(bowtie_command, stdout=myoutput, stderr=myoutput)
 		myoutput.close()
 		if proc != 0:
-			print 'Bowtie2 fails! Find Bowtie2 log file at' + bowtieLog
+			print 'Bowtie2 fails! Find Bowtie2 log file at ' + bowtieLog
 			return False, False, downloadedFiles
 	else:
 		print "0 fastq files found. Aborting..."

--- a/downloadAndBowtie.py
+++ b/downloadAndBowtie.py
@@ -207,28 +207,32 @@ def downloadAndBowtie(referencePath, run_id, target_dir, buildBowtie, picardJarP
 
 	print "Running bowtie..."
 	
-	bowtie_command = ['bowtie2', '-k', '2', '--quiet', '--no-unal', '-x', bowtieBuildFileName, str(''), str('--rg-id ENA --rg SM:' + run_id), '--sensitive-local', '--threads', str(threads), '--met-file', os.path.join(resultsFolder, str(run_id + '.bowtie_metrics.txt')), '-S', bowtie_output_file, ' ']
+	bowtie_command = ['bowtie2', '-k', '2', '--quiet', '--no-unal', '-x', bowtieBuildFileName, str(''), str('--rg-id ENA --rg SM:' + run_id), '--sensitive-local', '--threads', str(threads), '--met-file', os.path.join(resultsFolder, str(run_id + '.bowtie_metrics.txt')), '-S', bowtie_output_file]
 	
 	print os.listdir(dir_with_gz)
 	
 	if len(downloadedFiles)==1:
 		bowtie_command[7] = str('-U ' + os.path.join(dir_with_gz, downloadedFiles[0]))
 		print ' '.join(bowtie_command)
+		os.system(' '.join(bowtie_command))
+		'''
 		proc = subprocess.Popen(bowtie_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 		stdout, stderr = proc.communicate()
 		if proc.returncode != 0:
 			print 'Bowtie2 fails'
 			print stdout.decode("utf-8"), stderr.decode("utf-8")
-			return False, False, downloadedFiles
+			return False, False, downloadedFiles'''
 	elif len(downloadedFiles)==2:
 		bowtie_command[7] = str('-1 ' + os.path.join(dir_with_gz, downloadedFiles[0]) + ' -2 ' + os.path.join(dir_with_gz, downloadedFiles[1]))
 		print ' '.join(bowtie_command)
+		os.system(' '.join(bowtie_command))
+		'''
 		proc = subprocess.Popen(bowtie_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 		stdout, stderr = proc.communicate()
 		if proc.returncode != 0:
 			print 'Bowtie2 fails'
 			print stdout.decode("utf-8"), stderr.decode("utf-8")
-			return False, False, downloadedFiles
+			return False, False, downloadedFiles'''
 	else:
 		print "0 fastq files found. Aborting..."
 		os.system('rm -r ' + dir_with_gz)

--- a/downloadAndBowtie.py
+++ b/downloadAndBowtie.py
@@ -207,7 +207,7 @@ def downloadAndBowtie(referencePath, run_id, target_dir, buildBowtie, picardJarP
 
 	print "Running bowtie..."
 	
-	bowtie_command = ['bowtie2', '-k', '2', '--quiet', '--no-unal', '-x', bowtieBuildFileName, str(''), str('--rg-id ENA --rg SM:' + run_id), '--sensitive-local', '--threads', str(threads), '--met-file', os.path.join(resultsFolder, str(run_id + '.bowtie_metrics.txt')), '-S', bowtie_output_file]
+	bowtie_command = ['bowtie2', '-k', '2', '--quiet', '--no-unal', '-x', bowtieBuildFileName, str(''), str('--rg-id ENA --rg SM:' + run_id), '--sensitive-local', '--threads', str(threads), '--met-file', os.path.join(resultsFolder, str(run_id + '.bowtie_metrics.txt')), '-S', bowtie_output_file, '']
 	
 	print os.listdir(dir_with_gz)
 	

--- a/downloadAndBowtie.py
+++ b/downloadAndBowtie.py
@@ -202,6 +202,7 @@ def downloadAndBowtie(referencePath, run_id, target_dir, buildBowtie, picardJarP
 		os.makedirs(resultsFolder)
 	
 	bowtie_output_file=os.path.join(resultsFolder, str(run_id + '.sam'))
+	bowtieLog = os.path.join(resultsFolder, run_id + "_bowtie_error.txt")
 	
 	pairedOrSingle="Single_end"	
 
@@ -213,28 +214,25 @@ def downloadAndBowtie(referencePath, run_id, target_dir, buildBowtie, picardJarP
 	
 	if len(downloadedFiles)==1:
 		bowtie_command[7] = str('-U ' + os.path.join(dir_with_gz, downloadedFiles[0]))
-		print ' '.join(bowtie_command)
-		# os.system(' '.join(bowtie_command))
-		proc = subprocess.Popen(bowtie_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-		stdout, stderr = proc.communicate()
-		if proc.returncode != 0:
-			print 'Bowtie2 fails'
-			print stdout.decode("utf-8"), stderr.decode("utf-8")
+		myoutput = open(bowtieLog, 'w')
+		proc = subprocess.call(bowtie_command, stdout=myoutput, stderr=myoutput)
+		myoutput.close()
+		if proc != 0:
+			print 'Bowtie2 fails! Find Bowtie2 log file at' + bowtieLog
 			return False, False, downloadedFiles
 	elif len(downloadedFiles)==2:
 		bowtie_command[7] = str('-1 ' + os.path.join(dir_with_gz, downloadedFiles[0]) + ' -2 ' + os.path.join(dir_with_gz, downloadedFiles[1]))
-		print ' '.join(bowtie_command)
-		# os.system(' '.join(bowtie_command))
-		proc = subprocess.Popen(bowtie_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-		stdout, stderr = proc.communicate()
-		if proc.returncode != 0:
-			print 'Bowtie2 fails'
-			print stdout.decode("utf-8"), stderr.decode("utf-8")
+		myoutput = open(bowtieLog, 'w')
+		proc = subprocess.call(bowtie_command, stdout=myoutput, stderr=myoutput)
+		myoutput.close()
+		if proc != 0:
+			print 'Bowtie2 fails! Find Bowtie2 log file at' + bowtieLog
 			return False, False, downloadedFiles
 	else:
 		print "0 fastq files found. Aborting..."
 		os.system('rm -r ' + dir_with_gz)
 		return False, False, downloadedFiles
 
+	toClear.append(os.path.join(resultsFolder, run_id+"_bowtie_error.txt"))
 	toClear.append(os.path.join(resultsFolder, run_id+".bowtie_metrics.txt"))
 	return bowtie_output_file, pairedOrSingle, downloadedFiles

--- a/downloadAndBowtie.py
+++ b/downloadAndBowtie.py
@@ -86,7 +86,7 @@ def download_ERR(ERR_id,target_dir):
 					
 					
 						
-		except Exception, e:
+		except Exception as e:
 			failed +=1
 			print "Bad ID: " + ref
 		else:
@@ -97,7 +97,7 @@ def download_ERR(ERR_id,target_dir):
 	
 	try:
 		f.quit()
-	except Exception, e:
+	except Exception as e:
 		print e
 		print 'Insucess: ' + str(insucess)
 	print "Downloaded %s files successfully, %s fail and %s ID references were wrong" % (success,insucess,failed)
@@ -201,7 +201,7 @@ def downloadAndBowtie(referencePath, run_id, target_dir, buildBowtie, picardJarP
 	if not os.path.exists(resultsFolder):
 		os.makedirs(resultsFolder)
 	
-	bowtie_output_file=os.path.join(resultsFolder, run_id + ".sam")
+	bowtie_output_file=os.path.join(resultsFolder, str(run_id + '.sam'))
 	
 	pairedOrSingle="Single_end"	
 
@@ -209,8 +209,11 @@ def downloadAndBowtie(referencePath, run_id, target_dir, buildBowtie, picardJarP
 	
 	bowtie_command = ['bowtie2', '-k', '2', '--quiet', '--no-unal', '-x', bowtieBuildFileName, str(''), str('--rg-id ENA --rg SM:' + run_id), '--sensitive-local', '--threads', str(threads), '--met-file', os.path.join(resultsFolder, str(run_id + '.bowtie_metrics.txt')), '-S', bowtie_output_file]
 	
+	print os.listdir(dir_with_gz)
+	
 	if len(downloadedFiles)==1:
 		bowtie_command[7] = str('-U ' + os.path.join(dir_with_gz, downloadedFiles[0]))
+		print ' '.join(bowtie_command)
 		proc = subprocess.Popen(bowtie_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 		stdout, stderr = proc.communicate()
 		if proc.returncode != 0:
@@ -219,6 +222,7 @@ def downloadAndBowtie(referencePath, run_id, target_dir, buildBowtie, picardJarP
 			return False, False, downloadedFiles
 	elif len(downloadedFiles)==2:
 		bowtie_command[7] = str('-1 ' + os.path.join(dir_with_gz, downloadedFiles[0]) + ' -2 ' + os.path.join(dir_with_gz, downloadedFiles[1]))
+		print ' '.join(bowtie_command)
 		proc = subprocess.Popen(bowtie_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 		stdout, stderr = proc.communicate()
 		if proc.returncode != 0:

--- a/downloadAndBowtie.py
+++ b/downloadAndBowtie.py
@@ -214,6 +214,7 @@ def downloadAndBowtie(referencePath, run_id, target_dir, buildBowtie, picardJarP
 		proc = subprocess.Popen(bowtie_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 		stdout, stderr = proc.communicate()
 		if proc.returncode != 0:
+			print 'Bowtie2 fails'
 			print stdout.decode("utf-8"), stderr.decode("utf-8")
 			return False, False, downloadedFiles
 	elif len(downloadedFiles)==2:
@@ -221,6 +222,7 @@ def downloadAndBowtie(referencePath, run_id, target_dir, buildBowtie, picardJarP
 		proc = subprocess.Popen(bowtie_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 		stdout, stderr = proc.communicate()
 		if proc.returncode != 0:
+			print 'Bowtie2 fails'
 			print stdout.decode("utf-8"), stderr.decode("utf-8")
 			return False, False, downloadedFiles
 	else:

--- a/downloadAndBowtie.py
+++ b/downloadAndBowtie.py
@@ -207,7 +207,8 @@ def downloadAndBowtie(referencePath, run_id, target_dir, buildBowtie, picardJarP
 
 	print "Running bowtie..."
 	
-	bowtie_command = ['bowtie2', '-k', str(2), '--quiet', '--no-unal', '-x', bowtieBuildFileName, str('-U ' + os.path.join(dir_with_gz, downloadedFiles[0])), str('--rg-id ENA --rg SM:' + run_id), '--sensitive-local', '--threads', str(threads), '--met-file', os.path.join(resultsFolder, str(run_id + '.bowtie_metrics.txt')), '-S', bowtie_output_file]
+	print ' '.join('bowtie2', '-k', '2', '--quiet', '--no-unal', '-x', bowtieBuildFileName, str('-U ' + os.path.join(dir_with_gz, downloadedFiles[0])), str('--rg-id ENA --rg SM:' + run_id), '--sensitive-local', '--threads', str(threads), '--met-file', os.path.join(resultsFolder, str(run_id + '.bowtie_metrics.txt')), '-S', bowtie_output_file)
+	bowtie_command = ['bowtie2', '-k', '2', '--quiet', '--no-unal', '-x', bowtieBuildFileName, str('-U ' + os.path.join(dir_with_gz, downloadedFiles[0])), str('--rg-id ENA --rg SM:' + run_id), '--sensitive-local', '--threads', str(threads), '--met-file', os.path.join(resultsFolder, str(run_id + '.bowtie_metrics.txt')), '-S', bowtie_output_file]
 	
 	if len(downloadedFiles)==1:
 		proc = subprocess.Popen(bowtie_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/downloadAndBowtie.py
+++ b/downloadAndBowtie.py
@@ -207,10 +207,10 @@ def downloadAndBowtie(referencePath, run_id, target_dir, buildBowtie, picardJarP
 
 	print "Running bowtie..."
 	
-	print ' '.join('bowtie2', '-k', '2', '--quiet', '--no-unal', '-x', bowtieBuildFileName, str('-U ' + os.path.join(dir_with_gz, downloadedFiles[0])), str('--rg-id ENA --rg SM:' + run_id), '--sensitive-local', '--threads', str(threads), '--met-file', os.path.join(resultsFolder, str(run_id + '.bowtie_metrics.txt')), '-S', bowtie_output_file)
-	bowtie_command = ['bowtie2', '-k', '2', '--quiet', '--no-unal', '-x', bowtieBuildFileName, str('-U ' + os.path.join(dir_with_gz, downloadedFiles[0])), str('--rg-id ENA --rg SM:' + run_id), '--sensitive-local', '--threads', str(threads), '--met-file', os.path.join(resultsFolder, str(run_id + '.bowtie_metrics.txt')), '-S', bowtie_output_file]
+	bowtie_command = ['bowtie2', '-k', '2', '--quiet', '--no-unal', '-x', bowtieBuildFileName, str(''), str('--rg-id ENA --rg SM:' + run_id), '--sensitive-local', '--threads', str(threads), '--met-file', os.path.join(resultsFolder, str(run_id + '.bowtie_metrics.txt')), '-S', bowtie_output_file]
 	
 	if len(downloadedFiles)==1:
+		bowtie_command[7] = str('-U ' + os.path.join(dir_with_gz, downloadedFiles[0]))
 		proc = subprocess.Popen(bowtie_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 		stdout, stderr = proc.communicate()
 		if proc.returncode != 0:

--- a/downloadAndBowtie.py
+++ b/downloadAndBowtie.py
@@ -207,7 +207,7 @@ def downloadAndBowtie(referencePath, run_id, target_dir, buildBowtie, picardJarP
 
 	print "Running bowtie..."
 	
-	bowtie_command = ['bowtie2', '-k', '2', '--quiet', '--no-unal', '-x', bowtieBuildFileName, str(''), str('--rg-id ENA --rg SM:' + run_id), '--sensitive-local', '--threads', str(threads), '--met-file', os.path.join(resultsFolder, str(run_id + '.bowtie_metrics.txt')), '-S', bowtie_output_file, '']
+	bowtie_command = ['bowtie2', '-k', '2', '--quiet', '--no-unal', '-x', bowtieBuildFileName, str(''), str('--rg-id ENA --rg SM:' + run_id), '--sensitive-local', '--threads', str(threads), '--met-file', os.path.join(resultsFolder, str(run_id + '.bowtie_metrics.txt')), '-S', bowtie_output_file, ' ']
 	
 	print os.listdir(dir_with_gz)
 	

--- a/downloadAndBowtie.py
+++ b/downloadAndBowtie.py
@@ -212,7 +212,7 @@ def downloadAndBowtie(referencePath, run_id, target_dir, buildBowtie, picardJarP
 	
 	if len(downloadedFiles)==1:
 		bowtie_command[7] = str('-U ' + os.path.join(dir_with_gz, downloadedFiles[0]))
-		bowtie_command_splitted = shlex.split(bowtie_command)
+		bowtie_command_splitted = shlex.split(' '.join(bowtie_command))
 		'''
 		print ' '.join(bowtie_command)
 		myoutput = open(bowtieLog, 'w')
@@ -230,7 +230,7 @@ def downloadAndBowtie(referencePath, run_id, target_dir, buildBowtie, picardJarP
 			return False, False, downloadedFiles
 	elif len(downloadedFiles)==2:
 		bowtie_command[7] = str('-1 ' + os.path.join(dir_with_gz, downloadedFiles[0]) + ' -2 ' + os.path.join(dir_with_gz, downloadedFiles[1]))
-		bowtie_command_splitted = shlex.split(bowtie_command)
+		bowtie_command_splitted = shlex.split(' '.join(bowtie_command))
 		'''
 		print ' '.join(bowtie_command)
 		myoutput = open(bowtieLog, 'w')

--- a/downloadAndBowtie.py
+++ b/downloadAndBowtie.py
@@ -214,30 +214,27 @@ def downloadAndBowtie(referencePath, run_id, target_dir, buildBowtie, picardJarP
 	if len(downloadedFiles)==1:
 		bowtie_command[7] = str('-U ' + os.path.join(dir_with_gz, downloadedFiles[0]))
 		print ' '.join(bowtie_command)
-		os.system(' '.join(bowtie_command))
-		'''
-		proc = subprocess.Popen(bowtie_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+		# os.system(' '.join(bowtie_command))
+		proc = subprocess.Popen(bowtie_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
 		stdout, stderr = proc.communicate()
 		if proc.returncode != 0:
 			print 'Bowtie2 fails'
 			print stdout.decode("utf-8"), stderr.decode("utf-8")
-			return False, False, downloadedFiles'''
+			return False, False, downloadedFiles
 	elif len(downloadedFiles)==2:
 		bowtie_command[7] = str('-1 ' + os.path.join(dir_with_gz, downloadedFiles[0]) + ' -2 ' + os.path.join(dir_with_gz, downloadedFiles[1]))
 		print ' '.join(bowtie_command)
-		os.system(' '.join(bowtie_command))
-		'''
-		proc = subprocess.Popen(bowtie_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+		# os.system(' '.join(bowtie_command))
+		proc = subprocess.Popen(bowtie_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
 		stdout, stderr = proc.communicate()
 		if proc.returncode != 0:
 			print 'Bowtie2 fails'
 			print stdout.decode("utf-8"), stderr.decode("utf-8")
-			return False, False, downloadedFiles'''
+			return False, False, downloadedFiles
 	else:
 		print "0 fastq files found. Aborting..."
 		os.system('rm -r ' + dir_with_gz)
 		return False, False, downloadedFiles
 
 	toClear.append(os.path.join(resultsFolder, run_id+".bowtie_metrics.txt"))
-	toClear.append(os.path.join(resultsFolder, run_id+"_bowtie_error.txt"))
 	return bowtie_output_file, pairedOrSingle, downloadedFiles

--- a/mergeResults.py
+++ b/mergeResults.py
@@ -8,6 +8,9 @@ def mergeResults(workdir, sequenceCoverage, outdir):
 
 	#sampleList = os.listdir(workdir)
 	dirs = [d for d in os.listdir(workdir) if os.path.isdir(os.path.join(workdir, d))]
+	
+	print '\n' + 'Analysing ' + str(len(dirs)) + ' samples' + '\n'
+	
 	sampledict = {}
 	consensusdict = {}
 	prevNameSeq = ''
@@ -16,8 +19,8 @@ def mergeResults(workdir, sequenceCoverage, outdir):
 	for i in dirs:
 		countdirs+=1
 		time.sleep(0.1)
-		sys.stdout.write("\rChecking " + str(countdirs) + " of " + str(len(dirs)) + " folders...")
-		sys.stdout.flush()
+		sys.stderr.write("\rChecking " + str(countdirs) + " of " + str(len(dirs)) + " folders...")
+		sys.stderr.flush()
 		sampleName = os.path.basename(i)
 		mappingFilePath = os.path.join(workdir, sampleName, 'rematch_results', sampleName+'_mappingCheck.tab')
 		consensusFilePath = os.path.join(workdir, sampleName, 'rematch_results', sampleName+'_sequences.fasta')
@@ -40,25 +43,18 @@ def mergeResults(workdir, sequenceCoverage, outdir):
 				countSequences = -1
 				for line in consensusFile:
 					line = line.splitlines()[0]
-					# if '>' in line:
 					if line.startswith('>'):
 						nameseq = line[1:]
 						prevNameSeq = nameseq
 						nameseq = nameseq.replace(' ', '_')
 						if nameseq not in consensusdict:
 							consensusdict[nameseq] = []
-							# consensusdict[nameseq].append(['>' + sampleName + '_' + nameseq, False])
 							consensusdict[nameseq].append(['>' + sampleName + '-' + prevNameSeq, ''])
 						else:
-							# consensusdict[nameseq].append(['>' + sampleName + '_' + nameseq, False])
 							consensusdict[nameseq].append(['>' + sampleName + '-' + prevNameSeq, ''])
-						# prevNameSeq = nameseq
 						countSequences=len(consensusdict[nameseq])-1
 					else:
-						#print consensusdict
-						# consensusdict[prevNameSeq][countSequences][1] = line 
 						consensusdict[nameseq][countSequences][1] = consensusdict[nameseq][countSequences][1] + line
-						#print consensusdict[prevNameSeq][countSequences]
 	print "\nWriting results..."
 	
 	if not os.path.exists(os.path.join(outdir, 'merged_results')):
@@ -86,7 +82,6 @@ def mergeResults(workdir, sequenceCoverage, outdir):
 
 	
 	for x in consensusdict:
-		# with open(os.path.join(workdir, 'merged_results', 'consensus_sequences', x.strip('\n').strip(' ') + '_merged_sequences.fasta'),'w') as sequenceResults:
 		with open(os.path.join(outdir, 'merged_results', 'consensus_sequences', x + '_merged_sequences.fasta'),'w') as sequenceResults:
 			for z in consensusdict[x]:
 				sequenceResults.write(z[0] + '\n')

--- a/mergeResults.py
+++ b/mergeResults.py
@@ -4,7 +4,7 @@ import sys
 import time
 
 
-def mergeResults(workdir, sequenceCoverage):
+def mergeResults(workdir, sequenceCoverage, outdir):
 
 	#sampleList = os.listdir(workdir)
 	dirs = [d for d in os.listdir(workdir) if os.path.isdir(os.path.join(workdir, d))]
@@ -61,11 +61,11 @@ def mergeResults(workdir, sequenceCoverage):
 						#print consensusdict[prevNameSeq][countSequences]
 	print "\nWriting results..."
 	
-	if not os.path.exists(os.path.join(workdir, 'merged_results')):
-		os.makedirs(os.path.join(workdir, 'merged_results'))
+	if not os.path.exists(os.path.join(outdir, 'merged_results')):
+		os.makedirs(os.path.join(outdir, 'merged_results'))
 
 	
-	with open(os.path.join(workdir, 'merged_results', 'mergedResults.tab'),'w') as results:
+	with open(os.path.join(outdir, 'merged_results', 'mergedResults.tab'),'w') as results:
 		firstLine = True
 		header = 'Samples\t'
 
@@ -81,13 +81,13 @@ def mergeResults(workdir, sequenceCoverage):
 				row += sampledict[x][k] + '\t'
 			results.write(row + '\n')
 
-	if not os.path.exists(os.path.join(workdir, 'merged_results', 'consensus_sequences')):
-		os.makedirs(os.path.join(workdir, 'merged_results', 'consensus_sequences'))
+	if not os.path.exists(os.path.join(outdir, 'merged_results', 'consensus_sequences')):
+		os.makedirs(os.path.join(outdir, 'merged_results', 'consensus_sequences'))
 
 	
 	for x in consensusdict:
 		# with open(os.path.join(workdir, 'merged_results', 'consensus_sequences', x.strip('\n').strip(' ') + '_merged_sequences.fasta'),'w') as sequenceResults:
-		with open(os.path.join(workdir, 'merged_results', 'consensus_sequences', x + '_merged_sequences.fasta'),'w') as sequenceResults:
+		with open(os.path.join(outdir, 'merged_results', 'consensus_sequences', x + '_merged_sequences.fasta'),'w') as sequenceResults:
 			for z in consensusdict[x]:
 				sequenceResults.write(z[0] + '\n')
 				sequenceResults.write(z[1] + '\n')

--- a/mergeResults.py
+++ b/mergeResults.py
@@ -39,18 +39,25 @@ def mergeResults(workdir, sequenceCoverage):
 			with open(consensusFilePath, 'r') as consensusFile:
 				countSequences = -1
 				for line in consensusFile:
-					if '>' in line:
+					line = line.splitlines()[0]
+					# if '>' in line:
+					if line.startswith('>'):
 						nameseq = line[1:]
+						prevNameSeq = nameseq
+						nameseq = nameseq.replace(' ', '_')
 						if nameseq not in consensusdict:
 							consensusdict[nameseq] = []
-							consensusdict[nameseq].append(['>' + sampleName + '_' + nameseq, False])
+							# consensusdict[nameseq].append(['>' + sampleName + '_' + nameseq, False])
+							consensusdict[nameseq].append(['>' + sampleName + '-' + prevNameSeq, ''])
 						else:
-							consensusdict[nameseq].append(['>' + sampleName + '_' + nameseq, False])
-						prevNameSeq = nameseq
+							# consensusdict[nameseq].append(['>' + sampleName + '_' + nameseq, False])
+							consensusdict[nameseq].append(['>' + sampleName + '-' + prevNameSeq, ''])
+						# prevNameSeq = nameseq
 						countSequences=len(consensusdict[nameseq])-1
 					else:
 						#print consensusdict
-						consensusdict[prevNameSeq][countSequences][1] = line 
+						# consensusdict[prevNameSeq][countSequences][1] = line 
+						consensusdict[nameseq][countSequences][1] = consensusdict[nameseq][countSequences][1] + line
 						#print consensusdict[prevNameSeq][countSequences]
 	print "\nWriting results..."
 	
@@ -79,20 +86,8 @@ def mergeResults(workdir, sequenceCoverage):
 
 	
 	for x in consensusdict:
-		with open(os.path.join(workdir, 'merged_results', 'consensus_sequences', x.strip('\n').strip(' ') + '_merged_sequences.fasta'),'w') as sequenceResults:
+		# with open(os.path.join(workdir, 'merged_results', 'consensus_sequences', x.strip('\n').strip(' ') + '_merged_sequences.fasta'),'w') as sequenceResults:
+		with open(os.path.join(workdir, 'merged_results', 'consensus_sequences', x + '_merged_sequences.fasta'),'w') as sequenceResults:
 			for z in consensusdict[x]:
-				sequenceResults.write(z[0].strip('\n').strip(' ') + '\n')
-				sequenceResults.write(z[1].strip('\n').strip(' ') + '\n')
-
-	
-						
-
-
-
-
-
-
-	
-
-
-
+				sequenceResults.write(z[0] + '\n')
+				sequenceResults.write(z[1] + '\n')

--- a/rematch.py
+++ b/rematch.py
@@ -68,6 +68,13 @@ def main():
 			
 			sys.stdout = Logger(args.workdir)
 			checkPrograms(args)
+			
+			# Print arguments passed and shell PATH variable
+			print '\n' + 'COMMAND:'
+			print sys.executable + ' ' + os.path.abspath(sys.argv[0]) + ' ' + ' '.join(sys.argv[1:])
+			print '\n' + 'PATH variable:'
+			print os.environ['PATH']
+			
 			runReMaCh(args)
 			
 			end_time = time.time()

--- a/rematch.py
+++ b/rematch.py
@@ -53,15 +53,35 @@ def main():
 	mergedResults.add_argument('--mergeResultsOutdir', nargs=1, metavar=('/path/to/Results/Outdir/'), type=str, help='Specify a different directory from --workdir to output the merged results (otherwise merged results will be stored in --workdir). To be used with --mergeResults', required=False, default=None)
 
 	args = parser.parse_args()
-
+	
+	start_time = time.time()
+	
 	if args.mergeResults:
 		if args.mergeResultsOutdir == None:
-			mergeResultsOutdir = args.mergeResults[0]
+			mergeResultsOutdir = os.path.abspath(args.mergeResults[0])
 		else:
-			mergeResultsOutdir = args.mergeResultsOutdir[0]
-		print 'Running mergeResults with --mergeResults ' + str(args.mergeResults[0]) + ', --sequenceCoverage '+ str(args.sequenceCoverage) + ' and --mergeResultsOutdir '+ str(args.mergeResultsOutdir)
+			mergeResultsOutdir = os.path.abspath(args.mergeResultsOutdir[0])
+		
+		sys.stdout = Logger(mergeResultsOutdir)
+		print '\n' + 'LOGFILE: ' + sys.stdout.getLogFile()
+		
+		# Print arguments passed
+		print '\n' + 'COMMAND:'
+		print sys.executable + ' ' + os.path.abspath(sys.argv[0]) + ' ' + ' '.join(sys.argv[1:])
+		
 		mergeResults(args.mergeResults[0], args.sequenceCoverage, mergeResultsOutdir)
+	
 	else:
+		sys.stdout = Logger(args.workdir)
+		print '\n' + 'LOGFILE: ' + sys.stdout.getLogFile()
+		checkPrograms(args)
+		
+		# Print arguments passed and shell PATH variable
+		print '\n' + 'COMMAND:'
+		print sys.executable + ' ' + os.path.abspath(sys.argv[0]) + ' ' + ' '.join(sys.argv[1:])
+		print '\n' + 'PATH variable:'
+		print os.environ['PATH']
+		
 		if not args.r or not args.workdir or not args.gatk or not args.picard or not args.l:
 			parser.error('You must pass all the required arguments. For more information type -h')
 		else:
@@ -69,24 +89,13 @@ def main():
 				os.mkdir(args.workdir)
 				print str(args.workdir) + ' directory created!'
 			
-			start_time = time.time()
-			
-			sys.stdout = Logger(args.workdir)
-			checkPrograms(args)
-			
-			# Print arguments passed and shell PATH variable
-			print '\n' + 'COMMAND:'
-			print sys.executable + ' ' + os.path.abspath(sys.argv[0]) + ' ' + ' '.join(sys.argv[1:])
-			print '\n' + 'PATH variable:'
-			print os.environ['PATH']
-			
 			runReMaCh(args)
 			
-			end_time = time.time()
-			time_taken = end_time - start_time
-			hours, rest = divmod(time_taken,3600)
-			minutes, seconds = divmod(rest, 60)
-			print ">>> Runtime :" + str(hours) + "h:" + str(minutes) + "m:" + str(round(seconds, 2)) + "s" + "\n"
+	end_time = time.time()
+	time_taken = end_time - start_time
+	hours, rest = divmod(time_taken,3600)
+	minutes, seconds = divmod(rest, 60)
+	print ">>> Runtime :" + str(hours) + "h:" + str(minutes) + "m:" + str(round(seconds, 2)) + "s" + "\n"
 
 def runReMaCh(args):
 

--- a/rematch.py
+++ b/rematch.py
@@ -63,7 +63,7 @@ def main():
 			mergeResultsOutdir = os.path.abspath(args.mergeResultsOutdir[0])
 		
 		sys.stdout = Logger(mergeResultsOutdir)
-		# print '\n' + 'LOGFILE: ' + sys.stdout.getLogFile()
+		print '\n' + 'LOGFILE: ' + sys.stdout.getLogFile()
 		
 		# Print arguments passed
 		print '\n' + 'COMMAND:'
@@ -73,7 +73,8 @@ def main():
 	
 	else:
 		sys.stdout = Logger(args.workdir)
-		# print '\n' + 'LOGFILE: ' + sys.stdout.getLogFile()
+		print '\n' + 'LOGFILE: ' + sys.stdout.getLogFile()
+		
 		checkPrograms(args)
 		
 		# Print arguments passed and shell PATH variable

--- a/rematch.py
+++ b/rematch.py
@@ -8,6 +8,7 @@ import argparse
 from datetime import datetime
 import sys
 import glob
+import time
 
 from downloadAndBowtie import downloadAndBowtie
 from scriptAfterMapping import checkCoverage
@@ -32,7 +33,7 @@ def main():
 	requiredNamed.add_argument('-d', '--workdir', nargs="?", type=str, metavar=('/path/to/workdir'), help='Working directory. Downloaded files will be stored here under sampleID/fastq/, but it can also already contain folders with fastq files. Results will be stored here.', required=False)
 	requiredNamed.add_argument('-gatk', nargs="?", type=str, metavar=('/path/to/gatk.jar'), help='Path for the Genome Analysis Toolkit jar file', required=False)
 	requiredNamed.add_argument('-picard', nargs="?", metavar=('/path/to/picard'), type=str, help='Path for Picard', required=False)
-	requiredNamed.add_argument('-l', nargs="?", metavar=('/path/to/idenfifiersList.txt'), type=str, help='Path to a list with ids to run. IDs can be ENA run accession numbers for download or directory names where fastqs are stored in --workdir. Run accession numbers retrieved from ENA using -tax will be stored here.' , required=False)
+	requiredNamed.add_argument('-l', nargs="?", metavar=('/path/to/identifiersList.txt'), type=str, help='Path to a list with ids to run. IDs can be ENA run accession numbers for download or directory names where fastqs are stored in --workdir. Run accession numbers retrieved from ENA using -tax will be stored here.' , required=False)
 	parser.add_argument('-cov', '--minCoverage', nargs='?', metavar=('N'), type=int, help='Minimum coverage depth required for base calling and SNP calling.', default = 10, required=False)
 	parser.add_argument('-qual', '--minQuality', nargs='?', metavar=('N'), type=int, help='Minimum mapping quality for SNP calling', default = 10, required=False)
 	parser.add_argument('-mul', '--multipleAlleles', nargs='?', metavar=('0.0 - 1.0'), type=float, help='Minimum reads frequency (confidence) of dominant nucleotide to consider absence of multiple alleles at a given SNP position.', default = 0.75, required=False)

--- a/rematch.py
+++ b/rematch.py
@@ -50,12 +50,17 @@ def main():
 	mergedResults = parser.add_argument_group('merge results arguments. To be used after ReMatCh run')
 	mergedResults.add_argument('--mergeResults', nargs=1, metavar=('/path/to/workdir'), type=str, help='Merge all ReMatCh results available at --workdir. Option to be used alone or with --sequenceCoverage.', required=False)
 	mergedResults.add_argument('--sequenceCoverage', nargs=1, metavar=('0.0 - 1.0'), type=float, help='Minimum sequence length to consider the gene to be present. This is a relative measure. To be used with --mergeResults', default=0.8, required=False)
+	mergedResults.add_argument('--mergeResultsOutdir', nargs=1, metavar=('/path/to/Results/Outdir/'), type=str, help='Specify a different directory from --workdir to output the merged results (otherwise merged results will be stored in --workdir). To be used with --mergeResults', required=False, default=None)
 
 	args = parser.parse_args()
 
 	if args.mergeResults:
-		print 'Running mergeResults with --mergeResults ' + str(args.mergeResults[0]) + ' and --sequenceCoverage '+ str(args.sequenceCoverage)
-		mergeResults(args.mergeResults[0], args.sequenceCoverage)
+		if args.mergeResultsOutdir == None:
+			mergeResultsOutdir = args.mergeResults[0]
+		else:
+			mergeResultsOutdir = args.mergeResultsOutdir
+		print 'Running mergeResults with --mergeResults ' + str(args.mergeResults[0]) + ', --sequenceCoverage '+ str(args.sequenceCoverage) + ' and --mergeResultsOutdir '+ str(args.mergeResultsOutdir)
+		mergeResults(args.mergeResults[0], args.sequenceCoverage, mergeResultsOutdir)
 	else:
 		if not args.r or not args.workdir or not args.gatk or not args.picard or not args.l:
 			parser.error('You must pass all the required arguments. For more information type -h')

--- a/rematch.py
+++ b/rematch.py
@@ -164,7 +164,7 @@ def runReMaCh(args):
 				else:
 					ids_with_problems.write(run_id)
 					ids_with_problems.flush()
-					print 'An error has occurred: ' + str(len(filesDownloaded)) + 'fastq files were downloaded.'
+					print run_id + ' - An error has occurred.'
 			
 			if args.clean:
 				removeFromArray(toClear)

--- a/rematch.py
+++ b/rematch.py
@@ -63,7 +63,7 @@ def main():
 			mergeResultsOutdir = os.path.abspath(args.mergeResultsOutdir[0])
 		
 		sys.stdout = Logger(mergeResultsOutdir)
-		print '\n' + 'LOGFILE: ' + sys.stdout.getLogFile()
+		# print '\n' + 'LOGFILE: ' + sys.stdout.getLogFile()
 		
 		# Print arguments passed
 		print '\n' + 'COMMAND:'
@@ -73,7 +73,7 @@ def main():
 	
 	else:
 		sys.stdout = Logger(args.workdir)
-		print '\n' + 'LOGFILE: ' + sys.stdout.getLogFile()
+		# print '\n' + 'LOGFILE: ' + sys.stdout.getLogFile()
 		checkPrograms(args)
 		
 		# Print arguments passed and shell PATH variable

--- a/rematch.py
+++ b/rematch.py
@@ -62,11 +62,18 @@ def main():
 			if not os.path.isdir(args.workdir):
 				os.mkdir(args.workdir)
 				print str(args.workdir) + ' directory created!'
+			
+			start_time = time.time()
+			
 			sys.stdout = Logger(args.workdir)
 			checkPrograms(args)
 			runReMaCh(args)
-
-
+			
+			end_time = time.time()
+			time_taken = end_time - start_time
+			hours, rest = divmod(time_taken,3600)
+			minutes, seconds = divmod(rest, 60)
+			print ">>> Runtime :" + str(hours) + "h:" + str(minutes) + "m:" + str(round(seconds, 2)) + "s" + "\n"
 
 def runReMaCh(args):
 

--- a/rematch.py
+++ b/rematch.py
@@ -58,7 +58,7 @@ def main():
 		if args.mergeResultsOutdir == None:
 			mergeResultsOutdir = args.mergeResults[0]
 		else:
-			mergeResultsOutdir = args.mergeResultsOutdir
+			mergeResultsOutdir = args.mergeResultsOutdir[0]
 		print 'Running mergeResults with --mergeResults ' + str(args.mergeResults[0]) + ', --sequenceCoverage '+ str(args.sequenceCoverage) + ' and --mergeResultsOutdir '+ str(args.mergeResultsOutdir)
 		mergeResults(args.mergeResults[0], args.sequenceCoverage, mergeResultsOutdir)
 	else:

--- a/rematch.py
+++ b/rematch.py
@@ -59,6 +59,9 @@ def main():
 		if not args.r or not args.workdir or not args.gatk or not args.picard or not args.l:
 			parser.error('You must pass all the required arguments. For more information type -h')
 		else:
+			if not os.path.isdir(args.workdir):
+				os.mkdir(args.workdir)
+				print str(args.workdir) + ' directory created!'
 			sys.stdout = Logger(args.workdir)
 			checkPrograms(args)
 			runReMaCh(args)
@@ -69,10 +72,6 @@ def runReMaCh(args):
 
 	toClear = []
 
-	if not os.path.isdir(args.workdir):
-		os.mkdir(args.workdir)
-		print str(args.workdir) + ' directory created!'
-	
 	if args.tax:
 		GetSequencesFromTaxon(args.tax,args.l,True)
 	

--- a/rematch.py
+++ b/rematch.py
@@ -131,10 +131,6 @@ def runReMaCh(args):
 				#print "\n######\ndownloaded and bowtied\n######\n"
 				#logFile.write("\n######\ndownloaded and bowtied\n######\n")
 				
-				if len(filesDownloaded) == 0:
-					ids_with_problems.write(run_id + '\n')
-					pass
-
 				if not samFilePath==False:
 				
 					sortedPath = convertToBAM(samFilePath, toClear)
@@ -166,9 +162,9 @@ def runReMaCh(args):
 						runTimeFile.write("#runTime\tfileSize\tlibraryLayout\n")
 						runTimeFile.write(str(run_time) + '\t' + str(gzSizes) +"\t"+singOrPaired+ '\n')
 				else:
-					print "An error has ocurried: "+run_id+" fastQs do not exist."
-					#logFile.write("An error has ocurried: "+run_id+" fastQs do not exist.")
-					pass
+					ids_with_problems.write(run_id)
+					ids_with_problems.flush()
+					print 'An error has occurred: ' + str(len(filesDownloaded)) + 'fastq files were downloaded.'
 			
 			if args.clean:
 				removeFromArray(toClear)

--- a/rematch.py
+++ b/rematch.py
@@ -59,6 +59,7 @@ def main():
 		if not args.r or not args.workdir or not args.gatk or not args.picard or not args.l:
 			parser.error('You must pass all the required arguments. For more information type -h')
 		else:
+			sys.stdout = Logger(args.workdir)
 			checkPrograms(args)
 			runReMaCh(args)
 
@@ -80,9 +81,8 @@ def runReMaCh(args):
 	else:
 		platform=''
 	
-	sys.stdout = Logger(args.workdir)
-
 	ids_with_problems = open(os.path.join(args.workdir,'ids_with_problems.txt'), 'w')
+	ids_no_problems = open(os.path.join(args.workdir,'ids_no_problems.txt'), 'w')
 	#logFile = open(os.path.join(args.workdir,'log_file.txt'), 'a')
 
 	with open(args.l, 'r') as run_ids:
@@ -155,6 +155,9 @@ def runReMaCh(args):
 
 					if args.rmFastq:
 						os.system('rm -r ' + os.path.join(args.workdir, run_id, 'fastq'))
+					
+					ids_no_problems.write(run_id + "\n")
+					ids_no_problems.flush()
 
 					run_time = str(datetime.now() - startTime)
 
@@ -164,12 +167,18 @@ def runReMaCh(args):
 				else:
 					ids_with_problems.write(run_id + "\n")
 					ids_with_problems.flush()
+					if args.rmFastq:
+						try:
+							shutil.rmtree(os.path.join(args.workdir, run_id, 'fastq'))
+						except Exception as e:
+							print e
 					print run_id + ' - An error has occurred.'
 			
 			if args.clean:
 				removeFromArray(toClear)
 		
 		ids_with_problems.close()
+		ids_no_problems.close()
 
 		if args.clean:
 			removeIndexes(args.r)

--- a/rematch.py
+++ b/rematch.py
@@ -126,7 +126,7 @@ def runReMaCh(args):
 
 				run_id = run_id.strip()
 
-				print "\nChecking Run ID: " + str(run_id)
+				print "\nRunning ID: " + str(run_id)
 				samFilePath, singOrPaired, filesDownloaded = downloadAndBowtie(args.r, run_id, args.workdir, buildBowtie, args.picard, args.threads, toClear, args.asperaKey) # mpmachado #
 				#print "\n######\ndownloaded and bowtied\n######\n"
 				#logFile.write("\n######\ndownloaded and bowtied\n######\n")

--- a/rematch.py
+++ b/rematch.py
@@ -162,7 +162,7 @@ def runReMaCh(args):
 						runTimeFile.write("#runTime\tfileSize\tlibraryLayout\n")
 						runTimeFile.write(str(run_time) + '\t' + str(gzSizes) +"\t"+singOrPaired+ '\n')
 				else:
-					ids_with_problems.write(run_id)
+					ids_with_problems.write(run_id + "\n")
 					ids_with_problems.flush()
 					print run_id + ' - An error has occurred.'
 			

--- a/rematch_utils.py
+++ b/rematch_utils.py
@@ -127,6 +127,9 @@ def checkPrograms(args):
 				version_line=version_line.split('v')[1]
 			elif 'V' in version_line:
 				version_line=version_line.split('V')[1]
+			print program
+			print '.'.join(program_found_version[0:1]
+			print '.'.join(program_version_required[0:1
 			if programs[program][0] == '>=':
 				program_found_version = version_line.split('.')
 				program_version_required = programs[program][1].split('.')

--- a/rematch_utils.py
+++ b/rematch_utils.py
@@ -152,7 +152,8 @@ def removeIndexes(referencePath):
 
 	os.remove(referenceFileName+"_picard_out.txt")
 	os.remove(referenceFileName + ".dict")
-	os.remove(referencePath+'.fai')
+	if os.path.isfile(referencePath+'.fai'):
+		os.remove(referencePath+'.fai')
 	os.system('rm ' + referenceFileName + ".*.bt2")
 	os.remove(referenceFileName+"_bowtiBuildLog.txt")
 

--- a/rematch_utils.py
+++ b/rematch_utils.py
@@ -23,10 +23,12 @@ class Logger(object):
 		self.terminal.write(message)
 		self.log.write(message)
 		self.log.flush()
+		self.log.getLogFile()
 	def flush(self):
 		pass
 	def getLogFile(self):
-		return self.logfile
+		print '\n' + 'LOGFILE: ' + self.logfile
+
 
 def createCheckFile(bamSortedPath, sequenceMedObject):
 

--- a/rematch_utils.py
+++ b/rematch_utils.py
@@ -130,13 +130,9 @@ def checkPrograms(args):
 			if programs[program][0] == '>=':
 				program_found_version = version_line.split('.')
 				program_version_required = programs[program][1].split('.')
-				print program
-				print '.'.join(program_found_version[0:2])
-				print '.'.join(program_found_version[1:2])
-				print '.'.join(program_version_required[0:2])
-				if float('.'.join(program_found_version[0:1])) < float('.'.join(program_version_required[0:1])):
+				if float('.'.join(program_found_version[0:2])) < float('.'.join(program_version_required[0:2])):
 					listMissings.append('ReMatCh requires ' + program + ' with version ' + programs[program][1] + ' or above.')
-				elif float('.'.join(program_found_version[0:1])) == float('.'.join(program_version_required[0:1])):
+				elif float('.'.join(program_found_version[0:2])) == float('.'.join(program_version_required[0:2])):
 					if len(program_version_required) == 3:
 						if len(program_found_version) == 2:
 							program_found_version.append(0)

--- a/rematch_utils.py
+++ b/rematch_utils.py
@@ -98,7 +98,7 @@ def checkPrograms(args):
 
 	print '\nChecking dependencies...'
 	which_program = ['which', '']
-	programs = {'bedtools':['>=','2.22'], 'java':['>=', '1.8'], 'samtools':['=', '1.2'], 'bcftools':['=', '1.2'],'bowtie2':['>=','2.2.6'], 'ascp':['>=', '3.6.2']}
+	programs = {'bedtools':['>=','2.22'], 'java':['>=', '1.8'], 'samtools':['=', '1.2'], 'bcftools':['=', '1.2'],'bowtie2':['>=','2.2.6'], 'ascp':['>=', '3.6.1']}
 	listMissings = []
 	for program in programs:
 		if program =='ascp' and not args.asperaKey:

--- a/rematch_utils.py
+++ b/rematch_utils.py
@@ -127,9 +127,6 @@ def checkPrograms(args):
 				version_line=version_line.split('v')[1]
 			elif 'V' in version_line:
 				version_line=version_line.split('V')[1]
-			print program
-			print '.'.join(program_found_version[0:1])
-			print '.'.join(program_version_required[0:1])
 			if programs[program][0] == '>=':
 				program_found_version = version_line.split('.')
 				program_version_required = programs[program][1].split('.')

--- a/rematch_utils.py
+++ b/rematch_utils.py
@@ -98,7 +98,7 @@ def checkPrograms(args):
 
 	print '\nChecking dependencies...'
 	which_program = ['which', '']
-	programs = {'bedtools':['>=','2.22'], 'java':['>=', '1.8'], 'samtools':['=', '1.2'], 'bcftools':['=', '1.2'],'bowtie2':['>=','2.2.6'], 'ascp':['=', '3.6.2']}
+	programs = {'bedtools':['>=','2.22'], 'java':['>=', '1.8'], 'samtools':['=', '1.2'], 'bcftools':['=', '1.2'],'bowtie2':['>=','2.2.6'], 'ascp':['>=', '3.6.2']}
 	listMissings = []
 	for program in programs:
 		if program =='ascp' and not args.asperaKey:
@@ -131,8 +131,9 @@ def checkPrograms(args):
 				program_found_version = version_line.split('.')
 				program_version_required = programs[program][1].split('.')
 				print program
+				print '.'.join(program_found_version[0:2])
 				print '.'.join(program_found_version[1:2])
-				print '.'.join(program_version_required[1:2])
+				print '.'.join(program_version_required[0:2])
 				if float('.'.join(program_found_version[0:1])) < float('.'.join(program_version_required[0:1])):
 					listMissings.append('ReMatCh requires ' + program + ' with version ' + programs[program][1] + ' or above.')
 				elif float('.'.join(program_found_version[0:1])) == float('.'.join(program_version_required[0:1])):

--- a/rematch_utils.py
+++ b/rematch_utils.py
@@ -128,8 +128,8 @@ def checkPrograms(args):
 			elif 'V' in version_line:
 				version_line=version_line.split('V')[1]
 			print program
-			print '.'.join(program_found_version[0:1]
-			print '.'.join(program_version_required[0:1]
+			print '.'.join(program_found_version[0:1])
+			print '.'.join(program_version_required[0:1])
 			if programs[program][0] == '>=':
 				program_found_version = version_line.split('.')
 				program_version_required = programs[program][1].split('.')

--- a/rematch_utils.py
+++ b/rematch_utils.py
@@ -23,11 +23,12 @@ class Logger(object):
 		self.terminal.write(message)
 		self.log.write(message)
 		self.log.flush()
-		self.log.getLogFile()
-	def flush(self):
-		pass
-	def getLogFile(self):
 		print '\n' + 'LOGFILE: ' + self.logfile
+		# self.log.getLogFile()
+	# def flush(self):
+		# pass
+	# def getLogFile(self):
+		# print '\n' + 'LOGFILE: ' + self.logfile
 
 
 def createCheckFile(bamSortedPath, sequenceMedObject):

--- a/rematch_utils.py
+++ b/rematch_utils.py
@@ -23,8 +23,8 @@ class Logger(object):
 		self.terminal.write(message)
 		self.log.write(message)
 		self.log.flush()
-	# def flush(self):
-		# pass
+	def flush(self):
+		pass
 	def getLogFile(self):
 		return self.logfile
 

--- a/rematch_utils.py
+++ b/rematch_utils.py
@@ -136,7 +136,7 @@ def checkPrograms(args):
 					if len(program_version_required) == 3:
 						if len(program_found_version) == 2:
 							program_found_version.append(0)
-						if program_found_version[2] < program_version_required[2]
+						if program_found_version[2] < program_version_required[2]:
 							listMissings.append('ReMatCh requires ' + program + ' with version ' + programs[program][1] + ' or above.')
 			else:
 				if version_line != programs[program][1]:

--- a/rematch_utils.py
+++ b/rematch_utils.py
@@ -133,6 +133,9 @@ def checkPrograms(args):
 			if programs[program][0] == '>=':
 				program_found_version = version_line.split('.')
 				program_version_required = programs[program][1].split('.')
+				print program
+				print '.'.join(program_found_version[0:1])
+				print '.'.join(program_version_required[0:1])
 				if float('.'.join(program_found_version[0:1])) < float('.'.join(program_version_required[0:1])):
 					listMissings.append('ReMatCh requires ' + program + ' with version ' + programs[program][1] + ' or above.')
 				elif float('.'.join(program_found_version[0:1])) == float('.'.join(program_version_required[0:1])):

--- a/rematch_utils.py
+++ b/rematch_utils.py
@@ -131,8 +131,8 @@ def checkPrograms(args):
 				program_found_version = version_line.split('.')
 				program_version_required = programs[program][1].split('.')
 				print program
-				print '.'.join(program_found_version[0:1])
-				print '.'.join(program_version_required[0:1])
+				print '.'.join(program_found_version[1:2])
+				print '.'.join(program_version_required[1:2])
 				if float('.'.join(program_found_version[0:1])) < float('.'.join(program_version_required[0:1])):
 					listMissings.append('ReMatCh requires ' + program + ' with version ' + programs[program][1] + ' or above.')
 				elif float('.'.join(program_found_version[0:1])) == float('.'.join(program_version_required[0:1])):

--- a/rematch_utils.py
+++ b/rematch_utils.py
@@ -9,12 +9,14 @@ import csv
 import numpy
 import shlex, subprocess,ftplib
 import os.path
+import time
 
 class Logger(object):
 	def __init__(self, out_directory):
-		self.logfile = os.path.join(out_directory, "run.log")
+		time_str = time.strftime("%Y%m%d-%H%M%S")
+		self.logfile = os.path.join(out_directory, str('run.' + time_str + '.log'))
 		if os.path.isfile(self.logfile):
-			print "\nLogfile already exists! It will be overwritten..." + "\n"
+			print '\n' + 'Logfile already exists! It will be overwritten...'
 		self.terminal = sys.stdout
 		self.log = open(self.logfile, "w")
 	def write(self, message):
@@ -23,8 +25,8 @@ class Logger(object):
 		self.log.flush()
 	def flush(self):
 		pass
-
-
+	def getLogFile(self):
+		return self.logfile
 
 def createCheckFile(bamSortedPath, sequenceMedObject):
 

--- a/rematch_utils.py
+++ b/rematch_utils.py
@@ -23,13 +23,10 @@ class Logger(object):
 		self.terminal.write(message)
 		self.log.write(message)
 		self.log.flush()
-		print '\n' + 'LOGFILE: ' + self.logfile
-		# self.log.getLogFile()
 	# def flush(self):
 		# pass
-	# def getLogFile(self):
-		# print '\n' + 'LOGFILE: ' + self.logfile
-
+	def getLogFile(self):
+		return self.logfile
 
 def createCheckFile(bamSortedPath, sequenceMedObject):
 

--- a/rematch_utils.py
+++ b/rematch_utils.py
@@ -128,13 +128,19 @@ def checkPrograms(args):
 			elif 'V' in version_line:
 				version_line=version_line.split('V')[1]
 			if programs[program][0] == '>=':
-				if float('.'.join(version_line.split('.')[1:2])) < float('.'.join(programs[program][1].split('.')[1:2])):
+				program_found_version = version_line.split('.')
+				program_version_required = programs[program][1].split('.')
+				if float('.'.join(program_found_version[0:1])) < float('.'.join(program_version_required[0:1])):
 					listMissings.append('ReMatCh requires ' + program + ' with version ' + programs[program][1] + ' or above.')
-					#sys.exit('ReMatCh requires ' + program + ' with version ' + programs[program][1] + ' or above.')
+				elif float('.'.join(program_found_version[0:1])) == float('.'.join(program_version_required[0:1])):
+					if len(program_version_required) == 3:
+						if len(program_found_version) == 2:
+							program_found_version.append(0)
+						if program_found_version[2] < program_version_required[2]
+							listMissings.append('ReMatCh requires ' + program + ' with version ' + programs[program][1] + ' or above.')
 			else:
 				if version_line != programs[program][1]:
 					listMissings.append('ReMatCh requires ' + program + ' with version ' + programs[program][1] + '.')
-					#sys.exit('ReMatCh requires ' + program + ' with version ' + programs[program][1] + '.')
 
 	if len(listMissings) > 0:
 		sys.exit('\nErrors:\n'+'\n'.join(listMissings) + '\n\nInstall all dependencies and try again.')

--- a/rematch_utils.py
+++ b/rematch_utils.py
@@ -129,7 +129,7 @@ def checkPrograms(args):
 				version_line=version_line.split('V')[1]
 			print program
 			print '.'.join(program_found_version[0:1]
-			print '.'.join(program_version_required[0:1
+			print '.'.join(program_version_required[0:1]
 			if programs[program][0] == '>=':
 				program_found_version = version_line.split('.')
 				program_version_required = programs[program][1].split('.')


### PR DESCRIPTION
Flush ids_with_problems to the file while running through the samples;
change the ids_with_problems to the samFilePath else condition in order
to include those that the download fail for at least one file
Check whether bowtie run or not (possible problems might occur using large datasets - in test)
Check whether reference.fai file exists before removing
Correct version check (now it can uses 0.0.0 information)
Change logger initialisation position, include ids_no_problens, when run fails remove fastq
Change mkdir workdir position